### PR TITLE
Convert to Sopel 7+ URL handling

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests
-sopel
+sopel>=7,<8


### PR DESCRIPTION
Technically the `@url` decorator works on older Sopel versions, but 1) they're no longer supported and 2) it stops handling links if the `url` (title-fetcher) plugin is disabled (sopel-irc/sopel#1489).

The trade-off here is that you can match more than one link in an IRC line with `@url` (I guess see sopel-irc/sopel#1757), but need to require at least Sopel 7.0 to make the plugin reliable without using `@rule`.

I added an upper bound on the Sopel version "just in case". No current API change plans should affect this plugin until after 9.x, but it's probably good to test and release version bumps around when new Sopel releases drop anyway.