### PR TITLE
Handle when `imdb` section is missing from config file entirely

### DIFF
--- a/sopel_modules/imdb/imdb.py
+++ b/sopel_modules/imdb/imdb.py
@@ -43,8 +43,11 @@ def imdb(bot, trigger):
     """
     Returns some information about a movie or series, like Title, Year, Rating, Genre and IMDB Link.
     """
-    if bot.config.imdb.api_key is None or bot.config.imdb.api_key == '':
-        return bot.reply("OMDb API key missing. Please configure this module.")
+    try:
+        if bot.config.imdb.api_key is None or bot.config.imdb.api_key == '':
+            return bot.reply("OMDb API key missing. Please configure this plugin.")
+    except AttributeError:
+        return bot.reply("Missing imdb plugin config section. Please configure it.")
 
     if not trigger.group(2):
         return


### PR DESCRIPTION
Previous behavior was for Sopel to spit out "Unexpected error ('Config' object has no attribute 'imdb')" if the section was not present.

Tried to catch this in setup() and fail loading, but it didn't work as expected and I got tired of trying things.