### PR TITLE
Finalize 1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 [![Python Tests](https://github.com/sopel-irc/sopel-imdb/actions/workflows/python-tests.yml/badge.svg?branch=master)](https://github.com/sopel-irc/sopel-imdb/actions/workflows/python-tests.yml)
 [![PyPI version](https://badge.fury.io/py/sopel-modules.imdb.svg)](https://badge.fury.io/py/sopel-modules.imdb)
-[![Total alerts](https://img.shields.io/lgtm/alerts/g/sopel-irc/sopel-imdb.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/sopel-irc/sopel-imdb/alerts/)
-[![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/sopel-irc/sopel-imdb.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/sopel-irc/sopel-imdb/context:python)
 
 **Maintainer:** [@RustyBower](https://github.com/rustybower)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,8 @@ namespaces = false
 
 [project]
 name = "sopel-imdb"
-version = "1.3.0.dev0"
-description = "A working re-implementation of the imdb module for Sopel"
+version = "1.3.0"
+description = "A re-implementation of the imdb plugin for Sopel"
 keywords = [
   "sopel",
   "plugin",
@@ -30,13 +30,11 @@ authors = [
 ]
 
 readme = "README.md"
-license = { text="MIT License" }
+license = { text="MIT" }
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
-    "License :: Eiffel Forum License (EFL)",
-    "License :: OSI Approved :: Eiffel Forum License",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
~~Includes further modernization to TOML metadata, converting license information to be PEP 639-compliant.~~ Dropped because not compatible with Python 3.8.

Requires confirmation from Rusty that MIT is the intended license.